### PR TITLE
feat: Can now pass in a desired resolution

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -37,4 +37,5 @@ Options:
     -r,--retry                number of retries [default: 3]
     -t,--timeout              timeout [default: 60s]
     -u,--url                  url of m3u8 file
+    -d,--desired-resolution   desired resolution. Example: 1920x1080
 ```


### PR DESCRIPTION
Allows a user to configure a desired resolution to be selected when multiple streams are available. Useful because the highest bitrate isn't necessarily the best resolution.

README.md updated alongside the clop documentation.