### PR TITLE
bugfix: set the default key for the segment

### DIFF
--- a/main.go
+++ b/main.go
@@ -305,6 +305,10 @@ func parseM3u8(m3u8URL string, desiredResolution string, data []byte) (*m3u8.Med
 				}
 				segment.URI = uri
 
+				if segment.Key == nil && mpl.Key != nil {
+					segment.Key = mpl.Key
+				}
+				
 				if segment.Key != nil && segment.Key.URI != "" {
 					uri, err := formatURI(m3u8URL, segment.Key.URI)
 					if err != nil {


### PR DESCRIPTION
decrypting a segment without a key usually fails, if the playlist has one